### PR TITLE
writing StatusOK header not needed

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -75,7 +75,6 @@ func upload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// All good
-	w.WriteHeader(http.StatusOK)
 	fmt.Fprintf(w, "OK, Successfully Uploaded\n http://%s/%s\n", r.Host, uuid)
 }
 


### PR DESCRIPTION
From http.ResponseWriter:
"If WriteHeader has not yet been called, Write calls WriteHeader(http.StatusOK) before writing the data."